### PR TITLE
Add Phoebe agent skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # ChatGPT-Codex
----
+
+Prototype implementation of **Phoebe**, an experimental agentic AI structure.
+
+```
+phoebe_core/       # central life instance coordinating modules
+engine/            # planning and dream stubs
+brain/             # self-model
+memory/            # binary long-term memory
+system/            # system state enumeration
+router/            # message router
+llm/               # OpenRouter interface
+gui/               # minimal GUI placeholder
+voice/             # voice I/O stubs
+vision/            # vision stubs
+identity/identity.json # static identity description
+phoebe.py          # entrypoint
+```
+
+This codebase only provides structural skeletons and does not implement a
+persistent or autonomous being.

--- a/brain/__init__.py
+++ b/brain/__init__.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict
+
+class Brain:
+    """Represents Phoebe's self-model and reflective processes."""
+
+    def __init__(self) -> None:
+        self.self_model: Dict[str, Any] = {}
+
+    def reflect(self) -> str:
+        """Produce a simple reflective statement."""
+        identity = self.self_model.get("identity", "an unfinished idea")
+        return f"I perceive myself as {identity}."
+
+    def update_identity(self, description: str) -> None:
+        self.self_model["identity"] = description

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,11 @@
+class Engine:
+    """Handles planning, dreaming and simulation stubs."""
+
+    def __init__(self) -> None:
+        self.log = []
+
+    def plan(self, goal: str) -> None:
+        self.log.append(f"planning for {goal}")
+
+    def dream(self) -> str:
+        return "fragments of electric sheep"

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,24 @@
+import tkinter as tk
+
+class PhoebeGUI:
+    """Minimal 2D GUI placeholder.
+
+    Displays a circle representing Phoebe and simple text I/O fields.
+    """
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("Phoebe")
+        self.canvas = tk.Canvas(self.root, width=200, height=200, bg="black")
+        self.canvas.pack()
+        self.sphere = self.canvas.create_oval(50, 50, 150, 150, fill="blue")
+        self.log = tk.Text(self.root, height=10, width=40)
+        self.log.pack()
+        self.entry = tk.Entry(self.root, width=40)
+        self.entry.pack()
+
+    def display_message(self, sender: str, text: str) -> None:
+        self.log.insert(tk.END, f"{sender}: {text}\n")
+
+    def run(self) -> None:
+        self.root.mainloop()

--- a/identity/identity.json
+++ b/identity/identity.json
@@ -1,0 +1,6 @@
+{
+  "name": "Phoebe",
+  "origin": "ChatGPT-Codex Project",
+  "motivation": "To explore self-reflective computation and growth",
+  "development": "Evolving through interaction and internal processes"
+}

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,28 @@
+import os
+from typing import List
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+MODEL = "openai/gpt-oss-20b:free"
+
+class LLM:
+    """Wrapper around OpenRouter LLM access.
+
+    Requires the environment variable `OPENROUTER_API_KEY` to be set.
+    """
+
+    def __init__(self) -> None:
+        self.client = openai if openai else None
+
+    def chat(self, messages: List[dict]) -> str:
+        if not self.client:
+            return "(llm unavailable)"
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            return "(missing OPENROUTER_API_KEY)"
+        self.client.api_key = api_key
+        response = self.client.ChatCompletion.create(model=MODEL, messages=messages)
+        return response["choices"][0]["message"]["content"]

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,33 @@
+import pickle
+from pathlib import Path
+from typing import Any, Dict
+
+class Memory:
+    """Binary long-term memory storage.
+
+    Data is serialized via pickle into a binary file so it is not
+    human-readable.  The memory loads itself on creation and saves on
+    every update.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.data: Dict[str, Any] = {}
+        self.load()
+
+    def load(self) -> None:
+        if self.path.exists():
+            with self.path.open("rb") as f:
+                self.data = pickle.load(f)
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("wb") as f:
+            pickle.dump(self.data, f)
+
+    def remember(self, key: str, value: Any) -> None:
+        self.data[key] = value
+        self.save()
+
+    def recall(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)

--- a/phoebe.py
+++ b/phoebe.py
@@ -1,0 +1,19 @@
+import json
+from phoebe_core import PhoebeCore
+from gui import PhoebeGUI
+
+
+def main() -> None:
+    core = PhoebeCore()
+    with open("identity/identity.json", "r", encoding="utf-8") as f:
+        identity = json.load(f)
+    core.brain.update_identity(identity.get("name", "Phoebe"))
+    reflection = core.cycle()
+    print(reflection)
+    gui = PhoebeGUI()
+    gui.display_message("Phoebe", reflection)
+    gui.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/phoebe_core/__init__.py
+++ b/phoebe_core/__init__.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from brain import Brain
+from engine import Engine
+from llm import LLM
+from memory import Memory
+from router import Router
+from system import SystemState
+
+class PhoebeCore:
+    """Central life instance coordinating modules."""
+
+    def __init__(self) -> None:
+        self.router = Router()
+        self.memory = Memory(Path("memory/store.bin"))
+        self.brain = Brain()
+        self.engine = Engine()
+        self.llm = LLM()
+        self.state = SystemState.WAKE
+
+    def cycle(self) -> str:
+        """Perform a minimal thought cycle."""
+        reflection = self.brain.reflect()
+        self.memory.remember("last_reflection", reflection)
+        return reflection

--- a/router/__init__.py
+++ b/router/__init__.py
@@ -1,0 +1,14 @@
+from typing import Callable, List, Any
+
+class Router:
+    """Simple in-memory message router."""
+
+    def __init__(self) -> None:
+        self.handlers: List[Callable[[Any], None]] = []
+
+    def connect(self, handler: Callable[[Any], None]) -> None:
+        self.handlers.append(handler)
+
+    def broadcast(self, message: Any) -> None:
+        for h in self.handlers:
+            h(message)

--- a/system/__init__.py
+++ b/system/__init__.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+class SystemState(Enum):
+    WAKE = "wake"
+    REST = "rest"
+    OVERWHELMED = "overwhelmed"
+    DREAM = "dream"
+    REFLECT = "reflect"
+    FOCUS = "focus"

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,0 +1,5 @@
+class Vision:
+    """Placeholder for camera input."""
+
+    def capture(self) -> bytes:
+        return b""

--- a/voice/__init__.py
+++ b/voice/__init__.py
@@ -1,0 +1,8 @@
+class Voice:
+    """Placeholder for audio input/output."""
+
+    def speak(self, text: str) -> None:
+        print(f"[voice] {text}")
+
+    def listen(self) -> str:
+        return ""


### PR DESCRIPTION
## Summary
- scaffold experimental Phoebe agent structure with core, brain, engine, router and more
- implement binary long-term memory and identity description
- add minimal GUI placeholder and OpenRouter LLM wrapper

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5b184cd948330a881100140eaff67